### PR TITLE
Continuous layer

### DIFF
--- a/app/include/zmk/events/keycode_state_changed.h
+++ b/app/include/zmk/events/keycode_state_changed.h
@@ -19,30 +19,13 @@ struct zmk_keycode_state_changed {
     int64_t timestamp;
 };
 
+typedef struct zmk_keycode_event_registry_item {
+    sys_snode_t node;
+    uint32_t keycode;
+    uint32_t event_count;
+} zmk_keycode_event_registry_item_t;
+
 ZMK_EVENT_DECLARE(zmk_keycode_state_changed);
 
-static inline struct zmk_keycode_state_changed_event *
-zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp) {
-    uint16_t page = ZMK_HID_USAGE_PAGE(encoded);
-    uint16_t id = ZMK_HID_USAGE_ID(encoded);
-    uint8_t implicit_modifiers = 0x00;
-    uint8_t explicit_modifiers = 0x00;
-
-    if (!page) {
-        page = HID_USAGE_KEY;
-    }
-
-    if (is_mod(page, id)) {
-        explicit_modifiers = SELECT_MODS(encoded);
-    } else {
-        implicit_modifiers = SELECT_MODS(encoded);
-    }
-
-    return new_zmk_keycode_state_changed(
-        (struct zmk_keycode_state_changed){.usage_page = page,
-                                           .keycode = id,
-                                           .implicit_modifiers = implicit_modifiers,
-                                           .explicit_modifiers = explicit_modifiers,
-                                           .state = pressed,
-                                           .timestamp = timestamp});
-}
+struct zmk_keycode_state_changed_event *
+zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp);

--- a/app/src/behaviors/behavior_to_layer.c
+++ b/app/src/behaviors/behavior_to_layer.c
@@ -23,13 +23,13 @@ static int to_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
     zmk_keymap_layer_to(binding->param1);
-    return ZMK_BEHAVIOR_TRANSPARENT;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int to_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
-    return ZMK_BEHAVIOR_TRANSPARENT;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_to_driver_api = {

--- a/app/src/behaviors/behavior_to_layer.c
+++ b/app/src/behaviors/behavior_to_layer.c
@@ -23,13 +23,13 @@ static int to_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
     zmk_keymap_layer_to(binding->param1);
-    return ZMK_BEHAVIOR_OPAQUE;
+    return ZMK_BEHAVIOR_TRANSPARENT;
 }
 
 static int to_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
-    return ZMK_BEHAVIOR_OPAQUE;
+    return ZMK_BEHAVIOR_TRANSPARENT;
 }
 
 static const struct behavior_driver_api behavior_to_driver_api = {

--- a/app/src/event_manager.c
+++ b/app/src/event_manager.c
@@ -19,6 +19,10 @@ extern struct zmk_event_subscription __event_subscriptions_end[];
 
 int zmk_event_manager_handle_from(zmk_event_t *event, uint8_t start_index) {
     int ret = 0;
+
+    if(!event)
+        goto release;
+
     uint8_t len = __event_subscriptions_end - __event_subscriptions_start;
     for (int i = start_index; i < len; i++) {
         struct zmk_event_subscription *ev_sub = __event_subscriptions_start + i;

--- a/app/src/event_manager.c
+++ b/app/src/event_manager.c
@@ -20,7 +20,7 @@ extern struct zmk_event_subscription __event_subscriptions_end[];
 int zmk_event_manager_handle_from(zmk_event_t *event, uint8_t start_index) {
     int ret = 0;
 
-    if(!event)
+    if (!event)
         goto release;
 
     uint8_t len = __event_subscriptions_end - __event_subscriptions_start;

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -64,7 +64,7 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
         event_found = false;
     }
 
-    if(!event_found || event_exhausted) // send only first and last event 
+    if(!event_found || event_exhausted) // send only first and last event
 
         return new_zmk_keycode_state_changed(
             (struct zmk_keycode_state_changed){.usage_page = page,
@@ -72,6 +72,6 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
                                                .implicit_modifiers = implicit_modifiers,
                                                .explicit_modifiers = explicit_modifiers,
                                                .state = pressed,
-                                               .timestamp = timestamp}); 
+                                               .timestamp = timestamp});
     return NULL;
 }

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -35,9 +35,9 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
 
     zmk_keycode_event_registry_item_t *event = NULL;
     SYS_SLIST_FOR_EACH_CONTAINER(&active_events_registry, event, node) {
-        if( event->keycode == encoded ) {
+        if(event->keycode == encoded) {
             event_found = true;
-            if( pressed )
+            if(pressed)
                 event->event_count++;
             else if (event->event_count > 0){
                 event->event_count--;
@@ -55,7 +55,7 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
         k_free(event);
     }
 
-    if ( !event_found ){
+    if (!event_found){
         event = k_malloc(sizeof(zmk_keycode_event_registry_item_t));
         memset (event, 0, sizeof(zmk_keycode_event_registry_item_t));
         event->keycode = encoded;
@@ -64,15 +64,14 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
         event_found = false;
     }
 
-    if(event_found && !event_exhausted)
-        return NULL;
+    if(!event_found || event_exhausted) // send only first and last event 
 
-
-    return new_zmk_keycode_state_changed(
-        (struct zmk_keycode_state_changed){.usage_page = page,
-                                           .keycode = id,
-                                           .implicit_modifiers = implicit_modifiers,
-                                           .explicit_modifiers = explicit_modifiers,
-                                           .state = pressed,
-                                           .timestamp = timestamp});
+        return new_zmk_keycode_state_changed(
+            (struct zmk_keycode_state_changed){.usage_page = page,
+                                               .keycode = id,
+                                               .implicit_modifiers = implicit_modifiers,
+                                               .explicit_modifiers = explicit_modifiers,
+                                               .state = pressed,
+                                               .timestamp = timestamp}); 
+    return NULL;
 }

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -63,7 +63,8 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
         sys_slist_append(&active_events_registry, &event->node);
     }
 
-    if (!event_found || event_exhausted) // send only first keypress and last release event of the same keycode
+    if (!event_found ||
+        event_exhausted) // send only first keypress and last release event of the same keycode
 
         return new_zmk_keycode_state_changed(
             (struct zmk_keycode_state_changed){.usage_page = page,

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -35,35 +35,35 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
 
     zmk_keycode_event_registry_item_t *event = NULL;
     SYS_SLIST_FOR_EACH_CONTAINER(&active_events_registry, event, node) {
-        if(event->keycode == encoded) {
+        if (event->keycode == encoded) {
             event_found = true;
-            if(pressed)
+            if (pressed)
                 event->event_count++;
-            else if (event->event_count > 0){
+            else if (event->event_count > 0) {
                 event->event_count--;
             }
 
-            if(event->event_count == 0)
+            if (event->event_count == 0)
                 event_exhausted = true;
 
             break;
         }
     }
 
-    if(event_exhausted){
+    if (event_exhausted) {
         sys_slist_find_and_remove(&active_events_registry, &event->node);
         k_free(event);
     }
 
-    if (!event_found){
+    if (!event_found) {
         event = k_malloc(sizeof(zmk_keycode_event_registry_item_t));
-        memset (event, 0, sizeof(zmk_keycode_event_registry_item_t));
+        memset(event, 0, sizeof(zmk_keycode_event_registry_item_t));
         event->keycode = encoded;
         event->event_count = 1;
         sys_slist_append(&active_events_registry, &event->node);
     }
 
-    if(!event_found || event_exhausted) // send only first keypress and last release event of the same keycode
+    if (!event_found || event_exhausted) // send only first keypress and last release event of the same keycode
 
         return new_zmk_keycode_state_changed(
             (struct zmk_keycode_state_changed){.usage_page = page,

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -6,5 +6,73 @@
 
 #include <zephyr/kernel.h>
 #include <zmk/events/keycode_state_changed.h>
+#include <string.h>
 
 ZMK_EVENT_IMPL(zmk_keycode_state_changed);
+
+static sys_slist_t active_events_registry = SYS_SLIST_STATIC_INIT(&active_events_registry);
+
+struct zmk_keycode_state_changed_event *
+zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp) {
+
+    uint16_t page = ZMK_HID_USAGE_PAGE(encoded);
+    uint16_t id = ZMK_HID_USAGE_ID(encoded);
+    uint8_t implicit_modifiers = 0x00;
+    uint8_t explicit_modifiers = 0x00;
+
+    if (!page) {
+        page = HID_USAGE_KEY;
+    }
+
+    if (is_mod(page, id)) {
+        explicit_modifiers = SELECT_MODS(encoded);
+    } else {
+        implicit_modifiers = SELECT_MODS(encoded);
+    }
+
+    bool event_found = false;
+    bool event_exhausted = false;
+
+    zmk_keycode_event_registry_item_t *event = NULL;
+    SYS_SLIST_FOR_EACH_CONTAINER(&active_events_registry, event, node) {
+        if( event->keycode == encoded ) {
+            event_found = true;
+            if( pressed )
+                event->event_count++;
+            else if (event->event_count > 0){
+                event->event_count--;
+            }
+
+            if(event->event_count == 0)
+                event_exhausted = true;
+
+            break;
+        }
+    }
+
+    if(event_exhausted){
+        sys_slist_find_and_remove(&active_events_registry, &event->node);
+        k_free(event);
+    }
+
+    if ( !event_found ){
+        event = k_malloc(sizeof(zmk_keycode_event_registry_item_t));
+        memset (event, 0, sizeof(zmk_keycode_event_registry_item_t));
+        event->keycode = encoded;
+        event->event_count = 1;
+        sys_slist_append(&active_events_registry, &event->node);
+        event_found = false;
+    }
+
+    if(event_found && !event_exhausted)
+        return NULL;
+
+
+    return new_zmk_keycode_state_changed(
+        (struct zmk_keycode_state_changed){.usage_page = page,
+                                           .keycode = id,
+                                           .implicit_modifiers = implicit_modifiers,
+                                           .explicit_modifiers = explicit_modifiers,
+                                           .state = pressed,
+                                           .timestamp = timestamp});
+}

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -61,10 +61,9 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
         event->keycode = encoded;
         event->event_count = 1;
         sys_slist_append(&active_events_registry, &event->node);
-        event_found = false;
     }
 
-    if(!event_found || event_exhausted) // send only first and last event
+    if(!event_found || event_exhausted) // send only first keypress and last release event of the same keycode
 
         return new_zmk_keycode_state_changed(
             (struct zmk_keycode_state_changed){.usage_page = page,


### PR DESCRIPTION
This patch enables different physical buttons with same logic function, say `&kp SPACE` act as physical buttons, connected electrically in parallel.

## Behaviour **without** a patch

1. Build custom layout having, say, `&kp SPACE` on left and right thumb clusters
2. Press and hold left space
3. Verify receiving space keypress event
4. Press and hold right space
5. Verify receiving one more space keypress event
6. Release either space button, while holding another
7. Verify receiving space release event
8. Release another space button
9. Verify receiving one more space release event

## Behaviour **with** a patch

1. Build custom layout having, say, `&kp SPACE` on left and right thumb clusters
2. Press and hold left space
3. Verify receiving space keypress event
4. Press and hold right space
5. Verify that no other space keypress event received
6. Release either space button, while holding another
7. Verify receiving no space release event
8. Release another space button
9. Verify receiving single space release event


<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
